### PR TITLE
Add revenue trend and property performance charts

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-[#3CA9E0] text-white hover:bg-[#2B91C0]',
+        secondary: 'border-transparent bg-gray-100 text-gray-800',
+        outline: 'text-gray-800',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />
+}
+
+export { Badge, badgeVariants }


### PR DESCRIPTION
## Summary
- add line/bar toggleable revenue & net income trend chart
- add property performance pie chart with metric selection
- create reusable Badge component

## Testing
- `pnpm lint` *(fails: Do not pass children as props, Unexpected any, etc.)*
- `pnpm type-check` *(fails: Parameter 'p' implicitly has an 'any' type, Property 'summary' does not exist on type 'never', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6899b61cb5108333ae764a1b1878eafc