### PR TITLE
feat: add month-year selection for trailing 12

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -623,9 +623,25 @@ export default function CashFlowPage() {
       startDate = `${year}-${String(quarterStartMonth + 1).padStart(2, "0")}-01`
       const quarterEndMonth = quarterStartMonth + 2
       const lastDay = new Date(year, quarterEndMonth + 1, 0).getDate()
-      endDate = `${year}-${String(quarterEndMonth + 1).padStart(2, "0")}-${lastDay}`
+      endDate = `${year}-${String(quarterEndMonth + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
+    } else if (timePeriod === "Trailing 12") {
+      const monthIndex = monthsList.indexOf(selectedMonth)
+      const year = Number.parseInt(selectedYear)
+
+      // Start date is 11 months before selected month
+      let startYear = year
+      let startMonth = monthIndex + 1 - 11
+      if (startMonth <= 0) {
+        startMonth += 12
+        startYear -= 1
+      }
+      startDate = `${startYear}-${String(startMonth).padStart(2, "0")}-01`
+
+      // End date is last day of selected month
+      const lastDay = new Date(year, monthIndex + 1, 0).getDate()
+      endDate = `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
     } else {
-      // Trailing 12
+      // Fallback Trailing 12 from current date
       const twelveMonthsAgo = new Date(now)
       twelveMonthsAgo.setMonth(now.getMonth() - 12)
       startDate = twelveMonthsAgo.toISOString().split("T")[0]
@@ -651,6 +667,12 @@ export default function CashFlowPage() {
       return `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
     } else if (timePeriod === "YTD") {
       return `YTD ${new Date().getFullYear()}`
+    } else if (timePeriod === "Trailing 12") {
+      const startMonth = getMonthName(getMonthFromDate(startDate)).slice(0, 3)
+      const endMonth = getMonthName(getMonthFromDate(endDate)).slice(0, 3)
+      const startYear = getYearFromDate(startDate)
+      const endYear = getYearFromDate(endDate)
+      return `${startMonth} ${startYear} - ${endMonth} ${endYear}`
     }
     return "Trailing 12 Months"
   }
@@ -1454,7 +1476,9 @@ export default function CashFlowPage() {
                     ? `${selectedMonth} ${selectedYear}`
                     : timePeriod === "Quarterly"
                       ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                      : `${timePeriod} Period`}
+                      : timePeriod === "Trailing 12"
+                        ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                        : `${timePeriod} Period`}
               </p>
               {/* ENHANCED: Updated header information with transfer mode */}
               <p className="text-xs text-blue-600 mt-1">
@@ -1580,8 +1604,10 @@ export default function CashFlowPage() {
               <option value="Custom">Custom Date Range</option>
             </select>
 
-            {/* Month Dropdown - Show for Monthly and Quarterly */}
-            {(timePeriod === "Monthly" || timePeriod === "Quarterly") && (
+            {/* Month Dropdown - Show for Monthly, Quarterly, and Trailing 12 */}
+            {(timePeriod === "Monthly" ||
+              timePeriod === "Quarterly" ||
+              timePeriod === "Trailing 12") && (
               <select
                 value={selectedMonth}
                 onChange={(e) => setSelectedMonth(e.target.value)}
@@ -1596,8 +1622,10 @@ export default function CashFlowPage() {
               </select>
             )}
 
-            {/* Year Dropdown - Show for Monthly and Quarterly */}
-            {(timePeriod === "Monthly" || timePeriod === "Quarterly") && (
+            {/* Year Dropdown - Show for Monthly, Quarterly, and Trailing 12 */}
+            {(timePeriod === "Monthly" ||
+              timePeriod === "Quarterly" ||
+              timePeriod === "Trailing 12") && (
               <select
                 value={selectedYear}
                 onChange={(e) => setSelectedYear(e.target.value)}

--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -606,8 +606,11 @@ export default function CashFlowPage() {
       startDate = customStartDate || "2024-01-01"
       endDate = customEndDate || "2024-12-31"
     } else if (timePeriod === "YTD") {
-      startDate = `${now.getFullYear()}-01-01`
-      endDate = now.toISOString().split("T")[0]
+      const monthIndex = monthsList.indexOf(selectedMonth)
+      const year = Number.parseInt(selectedYear)
+      startDate = `${year}-01-01`
+      const lastDay = new Date(year, monthIndex + 1, 0).getDate()
+      endDate = `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
     } else if (timePeriod === "Monthly") {
       const monthIndex = monthsList.indexOf(selectedMonth)
       const year = Number.parseInt(selectedYear)
@@ -666,7 +669,7 @@ export default function CashFlowPage() {
     } else if (timePeriod === "Quarterly") {
       return `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
     } else if (timePeriod === "YTD") {
-      return `YTD ${new Date().getFullYear()}`
+      return `January - ${selectedMonth} ${selectedYear}`
     } else if (timePeriod === "Trailing 12") {
       const startMonth = getMonthName(getMonthFromDate(startDate)).slice(0, 3)
       const endMonth = getMonthName(getMonthFromDate(endDate)).slice(0, 3)
@@ -1476,9 +1479,11 @@ export default function CashFlowPage() {
                     ? `${selectedMonth} ${selectedYear}`
                     : timePeriod === "Quarterly"
                       ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                      : timePeriod === "Trailing 12"
-                        ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
-                        : `${timePeriod} Period`}
+                      : timePeriod === "YTD"
+                        ? `January - ${selectedMonth} ${selectedYear}`
+                        : timePeriod === "Trailing 12"
+                          ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                          : `${timePeriod} Period`}
               </p>
               {/* ENHANCED: Updated header information with transfer mode */}
               <p className="text-xs text-blue-600 mt-1">
@@ -1604,9 +1609,10 @@ export default function CashFlowPage() {
               <option value="Custom">Custom Date Range</option>
             </select>
 
-            {/* Month Dropdown - Show for Monthly, Quarterly, and Trailing 12 */}
+            {/* Month Dropdown - Show for Monthly, Quarterly, YTD, and Trailing 12 */}
             {(timePeriod === "Monthly" ||
               timePeriod === "Quarterly" ||
+              timePeriod === "YTD" ||
               timePeriod === "Trailing 12") && (
               <select
                 value={selectedMonth}
@@ -1622,9 +1628,10 @@ export default function CashFlowPage() {
               </select>
             )}
 
-            {/* Year Dropdown - Show for Monthly, Quarterly, and Trailing 12 */}
+            {/* Year Dropdown - Show for Monthly, Quarterly, YTD, and Trailing 12 */}
             {(timePeriod === "Monthly" ||
               timePeriod === "Quarterly" ||
+              timePeriod === "YTD" ||
               timePeriod === "Trailing 12") && (
               <select
                 value={selectedYear}
@@ -1738,7 +1745,11 @@ export default function CashFlowPage() {
                       ? `For ${selectedMonth} ${selectedYear}`
                       : timePeriod === "Quarterly"
                         ? `For Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                        : `For ${timePeriod} Period`}
+                        : timePeriod === "YTD"
+                          ? `For January - ${selectedMonth} ${selectedYear}`
+                          : timePeriod === "Trailing 12"
+                            ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                            : `For ${timePeriod} Period`}
                   {selectedProperty !== "All Properties" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
                       Property: {selectedProperty}
@@ -1873,7 +1884,11 @@ export default function CashFlowPage() {
                       ? `For ${selectedMonth} ${selectedYear}`
                       : timePeriod === "Quarterly"
                         ? `For Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                        : `For ${timePeriod} Period`}
+                        : timePeriod === "YTD"
+                          ? `For January - ${selectedMonth} ${selectedYear}`
+                          : timePeriod === "Trailing 12"
+                            ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                            : `For ${timePeriod} Period`}
                   {selectedProperty !== "All Properties" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
                       Property: {selectedProperty}
@@ -2751,7 +2766,11 @@ export default function CashFlowPage() {
                       ? `For ${selectedMonth} ${selectedYear}`
                       : timePeriod === "Quarterly"
                         ? `For Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                        : `For ${timePeriod} Period`}
+                        : timePeriod === "YTD"
+                          ? `For January - ${selectedMonth} ${selectedYear}`
+                          : timePeriod === "Trailing 12"
+                            ? `For ${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                            : `For ${timePeriod} Period`}
                   {selectedProperty !== "All Properties" && (
                     <span className="ml-2 px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
                       Property: {selectedProperty}

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -365,25 +365,43 @@ export default function FinancialsPage() {
       }
 
       endDate = `${year}-${String(quarterEndMonth + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
+    } else if (timePeriod === "Trailing 12") {
+      const monthIndex = monthsList.indexOf(selectedMonth);
+      const year = Number.parseInt(selectedYear);
+
+      // Start date is 11 months before the selected month
+      let startYear = year;
+      let startMonth = monthIndex + 1 - 11;
+      if (startMonth <= 0) {
+        startMonth += 12;
+        startYear -= 1;
+      }
+      startDate = `${startYear}-${String(startMonth).padStart(2, "0")}-01`;
+
+      // End date is the last day of the selected month
+      const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+      let lastDay = daysInMonth[monthIndex];
+      if (
+        monthIndex === 1 &&
+        ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0)
+      ) {
+        lastDay = 29;
+      }
+      endDate = `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
     } else {
-      // Trailing 12 - calculate 12 months back from current date
+      // Fallback: use current date for trailing 12
       const now = new Date();
       const currentYear = now.getFullYear();
       const currentMonth = now.getMonth() + 1;
-
       let startYear = currentYear;
       let startMonth = currentMonth - 12;
       if (startMonth <= 0) {
         startMonth += 12;
         startYear -= 1;
       }
-
       startDate = `${startYear}-${String(startMonth).padStart(2, "0")}-01`;
-
       const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
       let lastDay = daysInMonth[currentMonth - 1];
-
-      // Handle leap year for February
       if (
         currentMonth === 2 &&
         ((currentYear % 4 === 0 && currentYear % 100 !== 0) ||
@@ -391,7 +409,6 @@ export default function FinancialsPage() {
       ) {
         lastDay = 29;
       }
-
       endDate = `${currentYear}-${String(currentMonth).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
     }
 
@@ -1419,7 +1436,9 @@ export default function FinancialsPage() {
                         ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
                         : timePeriod === "YTD"
                           ? `January - June ${selectedYear}`
-                          : `${timePeriod} Period`}
+                          : timePeriod === "Trailing 12"
+                            ? `${formatDateDisplay(currentStartDate)} - ${formatDateDisplay(currentEndDate)}`
+                            : `${timePeriod} Period`}
                 </p>
                 <p className="text-xs text-blue-600 mt-1">
                   💰 Using timezone-independent date handling for precise P&L
@@ -1530,8 +1549,10 @@ export default function FinancialsPage() {
               )}
             </div>
 
-            {/* Month/Year dropdowns for Monthly and Quarterly */}
-            {(timePeriod === "Monthly" || timePeriod === "Quarterly") && (
+            {/* Month/Year dropdowns for Monthly, Quarterly, and Trailing 12 */}
+            {(timePeriod === "Monthly" ||
+              timePeriod === "Quarterly" ||
+              timePeriod === "Trailing 12") && (
               <>
                 <div className="relative" ref={monthDropdownRef}>
                   <button

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -324,9 +324,23 @@ export default function FinancialsPage() {
       startDate = customStartDate || "2025-01-01";
       endDate = customEndDate || "2025-06-30";
     } else if (timePeriod === "YTD") {
+      const monthIndex = monthsList.indexOf(selectedMonth);
       const year = Number.parseInt(selectedYear);
       startDate = `${year}-01-01`;
-      endDate = `${year}-06-30`;
+
+      // Calculate last day of selected month without Date object
+      const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+      let lastDay = daysInMonth[monthIndex];
+
+      // Handle leap year for February
+      if (
+        monthIndex === 1 &&
+        ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0)
+      ) {
+        lastDay = 29;
+      }
+
+      endDate = `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`;
     } else if (timePeriod === "Monthly") {
       const monthIndex = monthsList.indexOf(selectedMonth);
       const year = Number.parseInt(selectedYear);
@@ -1435,7 +1449,7 @@ export default function FinancialsPage() {
                       : timePeriod === "Quarterly"
                         ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
                         : timePeriod === "YTD"
-                          ? `January - June ${selectedYear}`
+                          ? `January - ${selectedMonth} ${selectedYear}`
                           : timePeriod === "Trailing 12"
                             ? `${formatDateDisplay(currentStartDate)} - ${formatDateDisplay(currentEndDate)}`
                             : `${timePeriod} Period`}
@@ -1549,9 +1563,10 @@ export default function FinancialsPage() {
               )}
             </div>
 
-            {/* Month/Year dropdowns for Monthly, Quarterly, and Trailing 12 */}
+            {/* Month/Year dropdowns for Monthly, Quarterly, YTD, and Trailing 12 */}
             {(timePeriod === "Monthly" ||
               timePeriod === "Quarterly" ||
+              timePeriod === "YTD" ||
               timePeriod === "Trailing 12") && (
               <>
                 <div className="relative" ref={monthDropdownRef}>
@@ -1620,40 +1635,6 @@ export default function FinancialsPage() {
               </>
             )}
 
-            {/* Year dropdown for YTD */}
-            {timePeriod === "YTD" && (
-              <div className="relative" ref={yearDropdownRef}>
-                <button
-                  onClick={() => setYearDropdownOpen(!yearDropdownOpen)}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2"
-                  style={
-                    {
-                      "--tw-ring-color": BRAND_COLORS.primary + "33",
-                    } as React.CSSProperties
-                  }
-                >
-                  {selectedYear}
-                  <ChevronDown className="w-4 h-4 ml-2" />
-                </button>
-
-                {yearDropdownOpen && (
-                  <div className="absolute z-10 mt-1 w-32 bg-white border border-gray-200 rounded-lg shadow-lg max-h-60 overflow-y-auto">
-                    {yearsList.map((year) => (
-                      <button
-                        key={year}
-                        onClick={() => {
-                          setSelectedYear(year);
-                          setYearDropdownOpen(false);
-                        }}
-                        className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 first:rounded-t-lg last:rounded-b-lg"
-                      >
-                        {year}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
 
             {/* Property Filter */}
             <div className="relative" ref={propertyDropdownRef}>


### PR DESCRIPTION
## Summary
- allow selecting trailing 12 end month/year on P&L and cash flow pages
- show chosen trailing period range in page headers
- display month/year dropdowns when viewing trailing 12 results

## Testing
- `pnpm lint` *(fails: many existing lint errors)*
- `pnpm type-check` *(fails: type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e8389f48333a188020fb57cd409