### PR TITLE
Aggregate top performers by selected period

### DIFF
--- a/src/app/api/organizations/[orgId]/dashboard-summary/route.ts
+++ b/src/app/api/organizations/[orgId]/dashboard-summary/route.ts
@@ -34,8 +34,6 @@ interface Entry {
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
-  const month = Number.parseInt(url.searchParams.get("month") || "1", 10)
-  const year = Number.parseInt(url.searchParams.get("year") || "2024", 10)
   const classId = url.searchParams.get("class")
   const includeProperties = url.searchParams.get("includeProperties") === "true"
 
@@ -43,13 +41,26 @@ export async function GET(req: Request) {
     return NextResponse.json({ propertyBreakdown: [] })
   }
 
-  const startDate = `${year}-${String(month).padStart(2, "0")}-01`
-  const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-  let lastDay = daysInMonth[month - 1]
-  if (month === 2 && ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0)) {
-    lastDay = 29
+  const start = url.searchParams.get("start")
+  const end = url.searchParams.get("end")
+
+  let startDate: string
+  let endDate: string
+
+  if (start && end) {
+    startDate = start
+    endDate = end
+  } else {
+    const month = Number.parseInt(url.searchParams.get("month") || "1", 10)
+    const year = Number.parseInt(url.searchParams.get("year") || "2024", 10)
+    startDate = `${year}-${String(month).padStart(2, "0")}-01`
+    const daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    let lastDay = daysInMonth[month - 1]
+    if (month === 2 && ((year % 4 === 0 && year % 100 !== 0) || year % 400 === 0)) {
+      lastDay = 29
+    }
+    endDate = `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
   }
-  const endDate = `${year}-${String(month).padStart(2, "0")}-${String(lastDay).padStart(2, "0")}`
 
   let query = supabase
     .from("journal_entry_lines")

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -854,9 +854,9 @@ export default function FinancialOverviewPage() {
     try {
       setLoadingProperty(true)
       setPropertyError(null)
-      const endMonth = monthsList.indexOf(selectedMonth) + 1
+      const { startDate, endDate } = calculateDateRange()
       const res = await fetch(
-        `/api/organizations/${orgId}/dashboard-summary?month=${endMonth}&year=${selectedYear}&period=month&includeProperties=true`
+        `/api/organizations/${orgId}/dashboard-summary?start=${startDate}&end=${endDate}&includeProperties=true`
       )
       if (!res.ok) throw new Error("Failed to fetch property data")
       const json: { propertyBreakdown: PropertyPoint[] } = await res.json()
@@ -958,6 +958,12 @@ export default function FinancialOverviewPage() {
     { key: "expenses", label: "Expenses" },
     { key: "ni", label: "Net Income" },
   ] as const
+
+  const { startDate: propertyStart, endDate: propertyEnd } = calculateDateRange()
+  const propertySubtitle =
+    timePeriod === "Monthly"
+      ? `Ranked by net income for ${selectedMonth} ${selectedYear}`
+      : `Ranked by net income for ${formatDate(propertyStart)} - ${formatDate(propertyEnd)}`
 
   const TrendTooltip = ({ active, payload, label }) => {
     if (active && payload && payload.length) {
@@ -1602,9 +1608,7 @@ export default function FinancialOverviewPage() {
             <div className="bg-white rounded-lg shadow-sm overflow-hidden">
               <div className="p-6 border-b border-gray-200">
                 <h3 className="text-lg font-semibold text-gray-900">Top Performing Properties</h3>
-                <div className="text-sm text-gray-600 mt-1">
-                  Ranked by net income for {selectedMonth} {selectedYear}
-                </div>
+                <div className="text-sm text-gray-600 mt-1">{propertySubtitle}</div>
               </div>
               <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200">


### PR DESCRIPTION
## Summary
- fetch property performance for the selected date range so top performers match chosen period
- show date range in Top Performing Properties subtitle

## Testing
- `pnpm lint` *(fails: react/no-children-prop, @typescript-eslint/no-explicit-any, etc.)*
- `pnpm type-check` *(fails: implicit any, type errors in multiple pages)*

------
https://chatgpt.com/codex/tasks/task_e_689a9b78df9c83339c3b0a1db4ce8f91