### PR TITLE
Add AI financial assistant

### DIFF
--- a/src/app/api/ai/route.ts
+++ b/src/app/api/ai/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest) {
+  const { messages } = await req.json()
+  if (!process.env.OPENAI_API_KEY) {
+    return NextResponse.json({ error: 'Missing OpenAI API key' }, { status: 500 })
+  }
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-5',
+        messages,
+      }),
+    })
+    const data = await response.json()
+    const reply = data?.choices?.[0]?.message?.content || ''
+    return NextResponse.json({ reply })
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch AI response' }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,8 +6,6 @@ import Link from "next/link"
 import {
   DollarSign,
   TrendingUp,
-  Building2,
-  CreditCard,
   ArrowUpRight,
   ArrowDownRight,
   RefreshCw,
@@ -37,6 +35,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { supabase } from "@/lib/supabaseClient"
+import AIAssistant from "@/components/AIAssistant"
 
 // IAM CFO Brand Colors
 const BRAND_COLORS = {
@@ -1021,37 +1020,6 @@ export default function FinancialOverviewPage() {
     return null
   }
 
-  // Quick actions configuration
-  const quickActions = [
-    {
-      title: "P&L Statement",
-      description: "Detailed profit and loss analysis",
-      href: "/financials",
-      icon: BarChart3,
-      color: BRAND_COLORS.primary,
-    },
-    {
-      title: "Cash Flow Analysis",
-      description: "Track cash inflows and outflows",
-      href: "/cash-flow",
-      icon: TrendingUp,
-      color: BRAND_COLORS.success,
-    },
-    {
-      title: "Balance Sheet",
-      description: "Assets, liabilities, and equity",
-      href: "/balance-sheet",
-      icon: Building2,
-      color: BRAND_COLORS.secondary,
-    },
-    {
-      title: "Accounts Receivable",
-      description: "Customer payments and aging",
-      href: "/accounts-receivable",
-      icon: CreditCard,
-      color: BRAND_COLORS.warning,
-    },
-  ]
 
   if (error) {
     return (
@@ -1539,33 +1507,7 @@ export default function FinancialOverviewPage() {
 
             {/* Financial Health Summary */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-              {/* Quick Actions */}
-              <div className="bg-white rounded-lg shadow-sm overflow-hidden">
-                <div className="p-6 border-b border-gray-200">
-                  <h3 className="text-lg font-semibold text-gray-900">Quick Actions</h3>
-                  <div className="text-sm text-gray-600 mt-1">Access detailed financial reports</div>
-                </div>
-                <div className="p-6">
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    {quickActions.map((action) => (
-                      <Link
-                        key={action.title}
-                        href={action.href}
-                        className="group p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-md transition-all"
-                      >
-                        <div className="flex items-center mb-3">
-                          <action.icon className="w-6 h-6 mr-3" style={{ color: action.color }} />
-                          <h4 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
-                            {action.title}
-                          </h4>
-                        </div>
-                        <p className="text-sm text-gray-600">{action.description}</p>
-                        <div className="mt-2 text-xs text-blue-600 font-medium">View Details →</div>
-                      </Link>
-                    ))}
-                  </div>
-                </div>
-              </div>
+              <AIAssistant />
 
               {/* Alerts & Notifications */}
               <div className="bg-white rounded-lg shadow-sm overflow-hidden">

--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import jsPDF from 'jspdf'
+import { Send, FileText } from 'lucide-react'
+
+interface Message {
+  role: 'user' | 'assistant'
+  content: string
+}
+
+export default function AIAssistant() {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const sendMessage = async () => {
+    if (!input.trim()) return
+    const newMessages: Message[] = [...messages, { role: 'user' as const, content: input }]
+    setMessages(newMessages)
+    setInput('')
+    setLoading(true)
+    try {
+      const res = await fetch('/api/ai', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: newMessages }),
+      })
+      const data = await res.json()
+      setMessages([...newMessages, { role: 'assistant' as const, content: data.reply }])
+    } catch {
+      setMessages([...newMessages, { role: 'assistant' as const, content: 'Sorry, something went wrong.' }])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const downloadReport = () => {
+    const doc = new jsPDF()
+    let y = 10
+    messages.forEach((m) => {
+      const lines = doc.splitTextToSize(`${m.role === 'user' ? 'You' : 'AI'}: ${m.content}`, 180)
+      doc.text(lines, 10, y)
+      y += lines.length * 10
+    })
+    doc.save('ai-report.pdf')
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm overflow-hidden flex flex-col h-full">
+      <div className="p-6 border-b border-gray-200">
+        <h3 className="text-lg font-semibold text-gray-900">AI Financial Assistant</h3>
+        <div className="text-sm text-gray-600 mt-1">Ask questions to gain CFO-level insights</div>
+      </div>
+      <div className="flex-1 p-6 space-y-4 overflow-y-auto">
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            className={`p-3 rounded-lg max-w-[80%] whitespace-pre-wrap ${m.role === 'user' ? 'bg-blue-50 ml-auto' : 'bg-gray-100 mr-auto'}`}
+          >
+            {m.content}
+          </div>
+        ))}
+        {loading && <div className="text-gray-500 text-sm">Thinking...</div>}
+      </div>
+      <div className="p-4 border-t border-gray-200">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            sendMessage()
+          }}
+          className="flex items-center space-x-2"
+        >
+          <input
+            className="flex-1 border rounded px-3 py-2 text-sm"
+            placeholder="Ask a question..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="p-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            disabled={loading}
+          >
+            <Send className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            onClick={downloadReport}
+            className="p-2 border rounded"
+          >
+            <FileText className="w-4 h-4" />
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- replace Quick Actions section with an interactive AI Financial Assistant
- add API route that uses OpenAI GPT-5 for CFO-level insights
- enable chat history and PDF report generation

## Testing
- `pnpm lint --file src/components/AIAssistant.tsx --file src/app/api/ai/route.ts --file src/app/page.tsx`
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_689aa3adbc74833394c2efcfa9443f67