### PR TITLE
feat: center all headings and rename brand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# IAM CFO - Financial Management Platform
+# I AM CFO - Financial Management Platform
 
 A comprehensive financial management platform designed specifically for rental property businesses, integrating property management with advanced financial analytics.
 
-![IAM CFO Dashboard](https://img.shields.io/badge/Built%20with-React%20%7C%20TypeScript%20%7C%20Tailwind-blue)
+![I AM CFO Dashboard](https://img.shields.io/badge/Built%20with-React%20%7C%20TypeScript%20%7C%20Tailwind-blue)
 
 ## 🚀 Features
 

--- a/src/app/ClientRootLayout.tsx
+++ b/src/app/ClientRootLayout.tsx
@@ -11,7 +11,7 @@ import Image from "next/image"
 
 const inter = Inter({ subsets: ["latin"] })
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",
@@ -34,10 +34,10 @@ const BRAND_COLORS = {
   },
 }
 
-// IAM CFO Logo Component
+// I AM CFO Logo Component
 const IAMCFOLogo = ({ className = "w-8 h-8" }) => (
   <div className={`${className} flex items-center justify-center relative`}>
-    <Image src="/favicon.png" alt="IAM CFO Logo" width={32} height={32} />
+    <Image src="/favicon.png" alt="I AM CFO Logo" width={32} height={32} />
   </div>
 )
 
@@ -92,7 +92,7 @@ export default function ClientRootLayout({
               </div>
               <div className="flex flex-shrink-0 items-center px-4 py-4">
                 <IAMCFOLogo className="w-8 h-8 mr-3" />
-                <span className="text-xl font-bold text-gray-900">IAM CFO</span>
+                <span className="text-xl font-bold text-gray-900">I AM CFO</span>
               </div>
               <div className="mt-5 h-0 flex-1 overflow-y-auto">
                 <nav className="space-y-1 px-2">
@@ -134,7 +134,7 @@ export default function ClientRootLayout({
               <div className="flex flex-1 flex-col overflow-y-auto pt-5 pb-4">
                 <div className="flex flex-shrink-0 items-center px-4">
                   <IAMCFOLogo className="w-8 h-8 mr-3" />
-                  <span className="text-xl font-bold text-gray-900">IAM CFO</span>
+                  <span className="text-xl font-bold text-gray-900">I AM CFO</span>
                 </div>
                 <nav className="mt-5 flex-1 space-y-1 px-2">
                   {navigation.map((item) => {

--- a/src/app/accounts-payable/page.tsx
+++ b/src/app/accounts-payable/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { Users, Clock, AlertCircle, CheckCircle, RefreshCw, Search, Calendar } from "lucide-react"
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",

--- a/src/app/accounts-receivable/page.tsx
+++ b/src/app/accounts-receivable/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import { CreditCard, Clock, AlertTriangle, CheckCircle, RefreshCw, Search } from "lucide-react"
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",

--- a/src/app/balance-sheet/page.tsx
+++ b/src/app/balance-sheet/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react"
 import { RefreshCw, X } from "lucide-react"
 import { supabase } from "@/lib/supabaseClient"
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",

--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -1813,9 +1813,11 @@ export default function CashFlowPage() {
                             {period.label}
                           </th>
                         ))}
-                        <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                          Total
-                        </th>
+                        {periodType !== "total" && (
+                          <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Total
+                          </th>
+                        )}
                       </tr>
                     </thead>
                     <tbody className="bg-white divide-y divide-gray-200">
@@ -1845,11 +1847,13 @@ export default function CashFlowPage() {
                               </td>
                             )
                           })}
-                          <td className="px-6 py-4 text-right">
-                            <span className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}>
-                              {formatCurrency(account.total)}
-                            </span>
-                          </td>
+                          {periodType !== "total" && (
+                            <td className="px-6 py-4 text-right">
+                              <span className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}>
+                                {formatCurrency(account.total)}
+                              </span>
+                            </td>
+                          )}
                         </tr>
                       ))}
 
@@ -1868,17 +1872,19 @@ export default function CashFlowPage() {
                             </td>
                           )
                         })}
-                        <td className="px-6 py-4 text-right">
-                          <span
-                            className={`font-bold text-xl ${
-                              bankAccountData.reduce((sum, acc) => sum + acc.total, 0) >= 0
-                                ? "text-green-700"
-                                : "text-red-700"
-                            }`}
-                          >
-                            {formatCurrency(bankAccountData.reduce((sum, acc) => sum + acc.total, 0))}
-                          </span>
-                        </td>
+                        {periodType !== "total" && (
+                          <td className="px-6 py-4 text-right">
+                            <span
+                              className={`font-bold text-xl ${
+                                bankAccountData.reduce((sum, acc) => sum + acc.total, 0) >= 0
+                                  ? "text-green-700"
+                                  : "text-red-700"
+                              }`}
+                            >
+                              {formatCurrency(bankAccountData.reduce((sum, acc) => sum + acc.total, 0))}
+                            </span>
+                          </td>
+                        )}
                       </tr>
                     </tbody>
                   </table>
@@ -2035,9 +2041,11 @@ export default function CashFlowPage() {
                                       {period.label}
                                     </th>
                                   ))}
-                                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Total
-                                  </th>
+                                  {periodType !== "total" && (
+                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Total
+                                    </th>
+                                  )}
                                 </tr>
                               </thead>
                               <tbody className="bg-white divide-y divide-gray-200">
@@ -2069,13 +2077,15 @@ export default function CashFlowPage() {
                                         </td>
                                       )
                                     })}
-                                    <td className="px-6 py-4 text-right">
-                                      <span
-                                        className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
-                                      >
-                                        {formatCurrency(account.total)}
-                                      </span>
-                                    </td>
+                                    {periodType !== "total" && (
+                                      <td className="px-6 py-4 text-right">
+                                        <span
+                                          className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
+                                        >
+                                          {formatCurrency(account.total)}
+                                        </span>
+                                      </td>
+                                    )}
                                   </tr>
                                 ))}
 
@@ -2099,13 +2109,15 @@ export default function CashFlowPage() {
                                       </td>
                                     )
                                   })}
-                                  <td className="px-6 py-4 text-right">
-                                    <span
-                                      className={`font-bold text-xl ${operatingTotal >= 0 ? "text-green-700" : "text-red-700"}`}
-                                    >
-                                      {formatCurrency(operatingTotal)}
-                                    </span>
-                                  </td>
+                                  {periodType !== "total" && (
+                                    <td className="px-6 py-4 text-right">
+                                      <span
+                                        className={`font-bold text-xl ${operatingTotal >= 0 ? "text-green-700" : "text-red-700"}`}
+                                      >
+                                        {formatCurrency(operatingTotal)}
+                                      </span>
+                                    </td>
+                                  )}
                                 </tr>
                               </tbody>
                             </table>
@@ -2162,9 +2174,11 @@ export default function CashFlowPage() {
                                       {period.label}
                                     </th>
                                   ))}
-                                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Total
-                                  </th>
+                                  {periodType !== "total" && (
+                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Total
+                                    </th>
+                                  )}
                                 </tr>
                               </thead>
                               <tbody className="bg-white divide-y divide-gray-200">
@@ -2196,13 +2210,15 @@ export default function CashFlowPage() {
                                         </td>
                                       )
                                     })}
-                                    <td className="px-6 py-4 text-right">
-                                      <span
-                                        className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
-                                      >
-                                        {formatCurrency(account.total)}
-                                      </span>
-                                    </td>
+                                    {periodType !== "total" && (
+                                      <td className="px-6 py-4 text-right">
+                                        <span
+                                          className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
+                                        >
+                                          {formatCurrency(account.total)}
+                                        </span>
+                                      </td>
+                                    )}
                                   </tr>
                                 ))}
 
@@ -2226,13 +2242,15 @@ export default function CashFlowPage() {
                                       </td>
                                     )
                                   })}
-                                  <td className="px-6 py-4 text-right">
-                                    <span
-                                      className={`font-bold text-xl ${financingTotal >= 0 ? "text-green-700" : "text-red-700"}`}
-                                    >
-                                      {formatCurrency(financingTotal)}
-                                    </span>
-                                  </td>
+                                  {periodType !== "total" && (
+                                    <td className="px-6 py-4 text-right">
+                                      <span
+                                        className={`font-bold text-xl ${financingTotal >= 0 ? "text-green-700" : "text-red-700"}`}
+                                      >
+                                        {formatCurrency(financingTotal)}
+                                      </span>
+                                    </td>
+                                  )}
                                 </tr>
                               </tbody>
                             </table>
@@ -2290,9 +2308,11 @@ export default function CashFlowPage() {
                                       {period.label}
                                     </th>
                                   ))}
-                                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Total
-                                  </th>
+                                  {periodType !== "total" && (
+                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Total
+                                    </th>
+                                  )}
                                 </tr>
                               </thead>
                               <tbody className="bg-white divide-y divide-gray-200">
@@ -2324,13 +2344,15 @@ export default function CashFlowPage() {
                                         </td>
                                       )
                                     })}
-                                    <td className="px-6 py-4 text-right">
-                                      <span
-                                        className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
-                                      >
-                                        {formatCurrency(account.total)}
-                                      </span>
-                                    </td>
+                                    {periodType !== "total" && (
+                                      <td className="px-6 py-4 text-right">
+                                        <span
+                                          className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
+                                        >
+                                          {formatCurrency(account.total)}
+                                        </span>
+                                      </td>
+                                    )}
                                   </tr>
                                 ))}
 
@@ -2354,13 +2376,15 @@ export default function CashFlowPage() {
                                       </td>
                                     )
                                   })}
-                                  <td className="px-6 py-4 text-right">
-                                    <span
-                                      className={`font-bold text-xl ${investingTotal >= 0 ? "text-green-700" : "text-red-700"}`}
-                                    >
-                                      {formatCurrency(investingTotal)}
-                                    </span>
-                                  </td>
+                                  {periodType !== "total" && (
+                                    <td className="px-6 py-4 text-right">
+                                      <span
+                                        className={`font-bold text-xl ${investingTotal >= 0 ? "text-green-700" : "text-red-700"}`}
+                                      >
+                                        {formatCurrency(investingTotal)}
+                                      </span>
+                                    </td>
+                                  )}
                                 </tr>
                               </tbody>
                             </table>
@@ -2419,9 +2443,11 @@ export default function CashFlowPage() {
                                         {period.label}
                                       </th>
                                     ))}
-                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                      Total
-                                    </th>
+                                    {periodType !== "total" && (
+                                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                        Total
+                                      </th>
+                                    )}
                                   </tr>
                                 </thead>
                                 <tbody className="bg-white divide-y divide-gray-200">
@@ -2456,13 +2482,15 @@ export default function CashFlowPage() {
                                           </td>
                                         )
                                       })}
-                                      <td className="px-6 py-4 text-right">
-                                        <span
-                                          className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
-                                        >
-                                          {formatCurrency(account.total)}
-                                        </span>
-                                      </td>
+                                      {periodType !== "total" && (
+                                        <td className="px-6 py-4 text-right">
+                                          <span
+                                            className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
+                                          >
+                                            {formatCurrency(account.total)}
+                                          </span>
+                                        </td>
+                                      )}
                                     </tr>
                                   ))}
 
@@ -2486,13 +2514,15 @@ export default function CashFlowPage() {
                                         </td>
                                       )
                                     })}
-                                    <td className="px-6 py-4 text-right">
-                                      <span
-                                        className={`font-bold text-xl ${transferTotal >= 0 ? "text-green-700" : "text-red-700"}`}
-                                      >
-                                        {formatCurrency(transferTotal)}
-                                      </span>
-                                    </td>
+                                    {periodType !== "total" && (
+                                      <td className="px-6 py-4 text-right">
+                                        <span
+                                          className={`font-bold text-xl ${transferTotal >= 0 ? "text-green-700" : "text-red-700"}`}
+                                        >
+                                          {formatCurrency(transferTotal)}
+                                        </span>
+                                      </td>
+                                    )}
                                   </tr>
                                 </tbody>
                               </table>
@@ -2548,9 +2578,11 @@ export default function CashFlowPage() {
                                       {period.label}
                                     </th>
                                   ))}
-                                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Total
-                                  </th>
+                                  {periodType !== "total" && (
+                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Total
+                                    </th>
+                                  )}
                                 </tr>
                               </thead>
                               <tbody className="bg-white divide-y divide-gray-200">
@@ -2582,13 +2614,15 @@ export default function CashFlowPage() {
                                         </td>
                                       )
                                     })}
-                                    <td className="px-6 py-4 text-right">
-                                      <span
-                                        className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
-                                      >
-                                        {formatCurrency(account.total)}
-                                      </span>
-                                    </td>
+                                    {periodType !== "total" && (
+                                      <td className="px-6 py-4 text-right">
+                                        <span
+                                          className={`font-bold ${account.total >= 0 ? "text-green-600" : "text-red-600"}`}
+                                        >
+                                          {formatCurrency(account.total)}
+                                        </span>
+                                      </td>
+                                    )}
                                   </tr>
                                 ))}
 
@@ -2612,13 +2646,15 @@ export default function CashFlowPage() {
                                       </td>
                                     )
                                   })}
-                                  <td className="px-6 py-4 text-right">
-                                    <span
-                                      className={`font-bold text-xl ${otherTotal >= 0 ? "text-green-700" : "text-red-700"}`}
-                                    >
-                                      {formatCurrency(otherTotal)}
-                                    </span>
-                                  </td>
+                                  {periodType !== "total" && (
+                                    <td className="px-6 py-4 text-right">
+                                      <span
+                                        className={`font-bold text-xl ${otherTotal >= 0 ? "text-green-700" : "text-red-700"}`}
+                                      >
+                                        {formatCurrency(otherTotal)}
+                                      </span>
+                                    </td>
+                                  )}
                                 </tr>
                               </tbody>
                             </table>
@@ -2689,9 +2725,11 @@ export default function CashFlowPage() {
                                       {period.label}
                                     </th>
                                   ))}
-                                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Total
-                                  </th>
+                                  {periodType !== "total" && (
+                                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                      Total
+                                    </th>
+                                  )}
                                 </tr>
                               </thead>
                               <tbody className="bg-white divide-y divide-gray-200">
@@ -2733,29 +2771,31 @@ export default function CashFlowPage() {
                                       </td>
                                     )
                                   })}
-                                  <td className="px-6 py-4 text-right">
-                                    <span
-                                      className={`font-bold text-xl ${(() => {
-                                        const grandTotal =
-                                          accountsByClass.operating.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.financing.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.investing.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.transfer.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.other.reduce((sum, acc) => sum + acc.total, 0)
-                                        return grandTotal >= 0 ? "text-green-700" : "text-red-700"
-                                      })()}`}
-                                    >
-                                      {(() => {
-                                        const grandTotal =
-                                          accountsByClass.operating.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.financing.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.investing.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.transfer.reduce((sum, acc) => sum + acc.total, 0) +
-                                          accountsByClass.other.reduce((sum, acc) => sum + acc.total, 0)
-                                        return formatCurrency(grandTotal)
-                                      })()}
-                                    </span>
-                                  </td>
+                                  {periodType !== "total" && (
+                                    <td className="px-6 py-4 text-right">
+                                      <span
+                                        className={`font-bold text-xl ${(() => {
+                                          const grandTotal =
+                                            accountsByClass.operating.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.financing.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.investing.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.transfer.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.other.reduce((sum, acc) => sum + acc.total, 0)
+                                          return grandTotal >= 0 ? "text-green-700" : "text-red-700"
+                                        })()}`}
+                                      >
+                                        {(() => {
+                                          const grandTotal =
+                                            accountsByClass.operating.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.financing.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.investing.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.transfer.reduce((sum, acc) => sum + acc.total, 0) +
+                                            accountsByClass.other.reduce((sum, acc) => sum + acc.total, 0)
+                                          return formatCurrency(grandTotal)
+                                        })()}
+                                      </span>
+                                    </td>
+                                  )}
                                 </tr>
                               </tbody>
                             </table>

--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -98,7 +98,7 @@ interface BankAccountData {
 }
 
 type ViewMode = "offset" | "traditional" | "bybank"
-type PeriodType = "monthly" | "weekly"
+type PeriodType = "monthly" | "weekly" | "total"
 type TimePeriod = "Monthly" | "Quarterly" | "YTD" | "Trailing 12" | "Custom"
 
 // Generate months and years lists
@@ -778,7 +778,7 @@ export default function CashFlowPage() {
           const month = getMonthFromDate(tx.date)
           const year = getYearFromDate(tx.date)
           periodKey = `${year}-${month.toString().padStart(2, "0")}`
-        } else {
+        } else if (periodType === "weekly") {
           const date = getDateParts(tx.date)
           const year = date.year
           const startOfYear = new Date(year, 0, 1)
@@ -788,6 +788,8 @@ export default function CashFlowPage() {
             ) + 1
           const week = Math.ceil(dayOfYear / 7)
           periodKey = `${year}-W${week.toString().padStart(2, "0")}`
+        } else {
+          periodKey = "total"
         }
 
         periodSet.add(periodKey)
@@ -833,11 +835,13 @@ export default function CashFlowPage() {
             const monthNum = Number.parseInt(monthStr)
             label = `${getMonthName(monthNum)} ${year}`
             month = monthNum
-          } else {
+          } else if (periodType === "weekly") {
             const [year, weekStr] = key.split("-")
             const weekNum = Number.parseInt(weekStr.replace("W", ""))
             label = getWeekLabel(Number.parseInt(year), weekNum)
             week = weekNum
+          } else {
+            label = "Total"
           }
 
           return { key, label, month, week }
@@ -927,7 +931,7 @@ export default function CashFlowPage() {
           const month = getMonthFromDate(tx.date)
           const year = getYearFromDate(tx.date)
           periodKey = `${year}-${month.toString().padStart(2, "0")}`
-        } else {
+        } else if (periodType === "weekly") {
           const date = getDateParts(tx.date)
           const year = date.year
           const startOfYear = new Date(year, 0, 1)
@@ -937,6 +941,8 @@ export default function CashFlowPage() {
             ) + 1
           const week = Math.ceil(dayOfYear / 7)
           periodKey = `${year}-W${week.toString().padStart(2, "0")}`
+        } else {
+          periodKey = "total"
         }
 
         periodSet.add(periodKey)
@@ -982,11 +988,13 @@ export default function CashFlowPage() {
             const monthNum = Number.parseInt(monthStr)
             label = `${getMonthName(monthNum)} ${year}`
             month = monthNum
-          } else {
+          } else if (periodType === "weekly") {
             const [year, weekStr] = key.split("-")
             const weekNum = Number.parseInt(weekStr.replace("W", ""))
             label = getWeekLabel(Number.parseInt(year), weekNum)
             week = weekNum
+          } else {
+            label = "Total"
           }
 
           return { key, label, month, week }
@@ -1541,10 +1549,22 @@ export default function CashFlowPage() {
                   <button
                     onClick={() => setPeriodType("weekly")}
                     className={`px-3 py-1 text-sm rounded-md transition-colors ${
-                      periodType === "weekly" ? "bg-white text-gray-900 shadow-sm" : "text-gray-600 hover:text-gray-900"
+                      periodType === "weekly"
+                        ? "bg-white text-gray-900 shadow-sm"
+                        : "text-gray-600 hover:text-gray-900"
                     }`}
                   >
                     📊 Weekly
+                  </button>
+                  <button
+                    onClick={() => setPeriodType("total")}
+                    className={`px-3 py-1 text-sm rounded-md transition-colors ${
+                      periodType === "total"
+                        ? "bg-white text-gray-900 shadow-sm"
+                        : "text-gray-600 hover:text-gray-900"
+                    }`}
+                  >
+                    Σ Total
                   </button>
                 </div>
               )}

--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -8,7 +8,7 @@ import jsPDF from "jspdf"
 import autoTable from "jspdf-autotable"
 import { supabase } from "@/lib/supabaseClient"
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -30,7 +30,7 @@ import {
 } from "recharts"
 import Image from "next/image"
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",
@@ -916,10 +916,10 @@ const useDeviceType = () => {
   return deviceType
 }
 
-// IAM CFO Logo Component
+// I AM CFO Logo Component
 const IAMCFOLogo = ({ className = "w-8 h-8" }) => (
   <div className={`${className} flex items-center justify-center relative`}>
-    <Image src="/favicon.png" alt="IAM CFO Logo" width={32} height={32} />
+    <Image src="/favicon.png" alt="I AM CFO Logo" width={32} height={32} />
   </div>
 )
 
@@ -3109,7 +3109,7 @@ export default function MobileResponsiveFinancialsPage() {
             <div className="flex items-center">
               <IAMCFOLogo className="w-6 h-6 mr-3" />
               <div>
-                <h1 className="text-lg font-bold text-gray-900">IAM CFO</h1>
+                <h1 className="text-lg font-bold text-gray-900">I AM CFO</h1>
                 <p className="text-xs text-gray-600">
                   {deviceType === "mobile" ? "Mobile" : deviceType === "tablet" ? "Tablet" : "Desktop"} View
                 </p>

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -18,7 +18,7 @@ import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,15 @@ h6 {
   @apply text-center;
 }
 
+h1 + p,
+h2 + p,
+h3 + p,
+h4 + p,
+h5 + p,
+h6 + p {
+  @apply text-center;
+}
+
 /* Utility to freeze the first column of wide tables */
 .sticky-first-col th:first-child,
 .sticky-first-col td:first-child {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,15 @@ body {
   @apply bg-iamcfo-background text-iamcfo-text font-sans;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @apply text-center;
+}
+
 /* Utility to freeze the first column of wide tables */
 .sticky-first-col th:first-child,
 .sticky-first-col td:first-child {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next"
 import ClientRootLayout from "./ClientRootLayout"
 
 export const metadata: Metadata = {
-  title: "IAM CFO - Financial Dashboard",
+  title: "I AM CFO - Financial Dashboard",
   description: "Comprehensive financial management and reporting dashboard",
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1078,24 +1078,34 @@ export default function FinancialOverviewPage() {
       {/* Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex flex-col items-center text-center">
-            <h1 className="text-2xl font-bold text-gray-900">Financial Overview</h1>
-            <p className="text-sm text-gray-600 mt-1">
-              {timePeriod === "Custom"
-                ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
-                : timePeriod === "Monthly"
-                  ? `${selectedMonth} ${selectedYear}`
-                  : timePeriod === "Quarterly"
-                    ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                    : timePeriod === "YTD"
-                      ? `January - ${selectedMonth} ${selectedYear}`
-                      : timePeriod === "Trailing 12"
-                        ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
-                        : `${timePeriod} Period`}
-            </p>
-            {lastUpdated && (
-              <p className="text-xs text-gray-500 mt-1">Last updated: {lastUpdated.toLocaleString()}</p>
-            )}
+          <div className="relative flex justify-center">
+            <div className="flex flex-col items-center text-center">
+              <h1 className="text-2xl font-bold text-gray-900">Financial Overview</h1>
+              <p className="text-sm text-gray-600 mt-1">
+                {timePeriod === "Custom"
+                  ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                  : timePeriod === "Monthly"
+                    ? `${selectedMonth} ${selectedYear}`
+                    : timePeriod === "Quarterly"
+                      ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
+                      : timePeriod === "YTD"
+                        ? `January - ${selectedMonth} ${selectedYear}`
+                        : timePeriod === "Trailing 12"
+                          ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                          : `${timePeriod} Period`}
+              </p>
+              {lastUpdated && (
+                <p className="text-xs text-gray-500 mt-1">Last updated: {lastUpdated.toLocaleString()}</p>
+              )}
+            </div>
+            <button
+              onClick={fetchFinancialData}
+              disabled={isLoading}
+              className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-2 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
+              {isLoading ? "Loading..." : "Refresh"}
+            </button>
           </div>
         </div>
       </div>
@@ -1220,14 +1230,6 @@ export default function FinancialOverviewPage() {
                 />
               </div>
             )}
-            <button
-              onClick={fetchFinancialData}
-              disabled={isLoading}
-              className="flex items-center gap-2 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
-            >
-              <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
-              {isLoading ? "Loading..." : "Refresh"}
-            </button>
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1096,16 +1096,6 @@ export default function FinancialOverviewPage() {
             {lastUpdated && (
               <p className="text-xs text-gray-500 mt-1">Last updated: {lastUpdated.toLocaleString()}</p>
             )}
-            <div className="flex items-center space-x-4 mt-4">
-              <button
-                onClick={fetchFinancialData}
-                disabled={isLoading}
-                className="flex items-center gap-2 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
-              >
-                <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
-                {isLoading ? "Loading..." : "Refresh"}
-              </button>
-            </div>
           </div>
         </div>
       </div>
@@ -1230,6 +1220,14 @@ export default function FinancialOverviewPage() {
                 />
               </div>
             )}
+            <button
+              onClick={fetchFinancialData}
+              disabled={isLoading}
+              className="flex items-center gap-2 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors shadow-sm disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${isLoading ? "animate-spin" : ""}`} />
+              {isLoading ? "Loading..." : "Refresh"}
+            </button>
           </div>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
 import { supabase } from "@/lib/supabaseClient"
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: "#56B6E9",
   secondary: "#3A9BD1",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1078,28 +1078,25 @@ export default function FinancialOverviewPage() {
       {/* Header */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">Financial Overview</h1>
-              <p className="text-sm text-gray-600 mt-1">
-                {timePeriod === "Custom"
-                  ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
-                  : timePeriod === "Monthly"
-                    ? `${selectedMonth} ${selectedYear}`
-                    : timePeriod === "Quarterly"
-                      ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
-                      : timePeriod === "YTD"
-                        ? `January - ${selectedMonth} ${selectedYear}`
-                        : timePeriod === "Trailing 12"
-                          ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
-                          : `${timePeriod} Period`}
-              </p>
-              {lastUpdated && (
-                <p className="text-xs text-gray-500 mt-1">Last updated: {lastUpdated.toLocaleString()}</p>
-              )}
-            </div>
-
-            <div className="flex items-center space-x-4">
+          <div className="flex flex-col items-center text-center">
+            <h1 className="text-2xl font-bold text-gray-900">Financial Overview</h1>
+            <p className="text-sm text-gray-600 mt-1">
+              {timePeriod === "Custom"
+                ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                : timePeriod === "Monthly"
+                  ? `${selectedMonth} ${selectedYear}`
+                  : timePeriod === "Quarterly"
+                    ? `Q${Math.floor(monthsList.indexOf(selectedMonth) / 3) + 1} ${selectedYear}`
+                    : timePeriod === "YTD"
+                      ? `January - ${selectedMonth} ${selectedYear}`
+                      : timePeriod === "Trailing 12"
+                        ? `${formatDate(calculateDateRange().startDate)} - ${formatDate(calculateDateRange().endDate)}`
+                        : `${timePeriod} Period`}
+            </p>
+            {lastUpdated && (
+              <p className="text-xs text-gray-500 mt-1">Last updated: {lastUpdated.toLocaleString()}</p>
+            )}
+            <div className="flex items-center space-x-4 mt-4">
               <button
                 onClick={fetchFinancialData}
                 disabled={isLoading}
@@ -1110,8 +1107,8 @@ export default function FinancialOverviewPage() {
               </button>
             </div>
           </div>
+        </div>
       </div>
-    </div>
     
       {/* Filters */}
       <div className="bg-white border-b">

--- a/src/app/payroll/page.tsx
+++ b/src/app/payroll/page.tsx
@@ -15,7 +15,7 @@ import {
   ComposedChart
 } from 'recharts';
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: '#56B6E9',      // Your brand blue
   secondary: '#3A9BD1',    // Darker shade of your blue
@@ -140,7 +140,7 @@ interface NewEmployeeForm {
   paidTimeOff: string;
 }
 
-// IAM CFO Logo Component
+// I AM CFO Logo Component
 const IAMCFOLogo = ({ className = "w-8 h-8" }: { className?: string }) => (
   <div className={`${className} flex items-center justify-center relative`}>
     <svg viewBox="0 0 120 120" className="w-full h-full">
@@ -571,14 +571,14 @@ export default function PayrollPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Page Header with IAM CFO Branding */}
+      {/* Page Header with I AM CFO Branding */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center">
             <IAMCFOLogo className="w-8 h-8 mr-4" />
             <div>
               <div className="flex items-center space-x-3">
-                <h1 className="text-2xl font-bold text-gray-900">IAM CFO</h1>
+                <h1 className="text-2xl font-bold text-gray-900">I AM CFO</h1>
                 <span className="text-sm px-3 py-1 rounded-full text-white" style={{ backgroundColor: BRAND_COLORS.primary }}>
                   Payroll Management
                 </span>

--- a/src/app/reservations/page.tsx
+++ b/src/app/reservations/page.tsx
@@ -957,14 +957,14 @@ const loadDashboardData = async () => {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Page Header with IAM CFO Branding */}
+      {/* Page Header with I AM CFO Branding */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center">
             <IAMCFOLogo className="w-8 h-8 mr-4" />
             <div>
               <div className="flex items-center space-x-3">
-                <h1 className="text-2xl font-bold text-gray-900">IAM CFO</h1>
+                <h1 className="text-2xl font-bold text-gray-900">I AM CFO</h1>
                 <span className="text-sm px-3 py-1 rounded-full text-white" style={{ backgroundColor: BRAND_COLORS.primary }}>
                   Reservation Management
                 </span>

--- a/src/app/statements/page.tsx
+++ b/src/app/statements/page.tsx
@@ -17,7 +17,7 @@ import {
   ComposedChart
 } from 'recharts';
 
-// IAM CFO Brand Colors
+// I AM CFO Brand Colors
 const BRAND_COLORS = {
   primary: '#56B6E9',      // Your brand blue
   secondary: '#3A9BD1',    // Darker shade of your blue
@@ -119,7 +119,7 @@ interface NotificationState {
   type: 'info' | 'success' | 'error' | 'warning';
 }
 
-// IAM CFO Logo Component
+// I AM CFO Logo Component
 const IAMCFOLogo = ({ className = "w-8 h-8" }: { className?: string }) => (
   <div className={`${className} flex items-center justify-center relative`}>
     <svg viewBox="0 0 120 120" className="w-full h-full">
@@ -580,14 +580,14 @@ export default function StatementsPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Page Header with IAM CFO Branding */}
+      {/* Page Header with I AM CFO Branding */}
       <div className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex items-center">
             <IAMCFOLogo className="w-8 h-8 mr-4" />
             <div>
               <div className="flex items-center space-x-3">
-                <h1 className="text-2xl font-bold text-gray-900">IAM CFO</h1>
+                <h1 className="text-2xl font-bold text-gray-900">I AM CFO</h1>
                 <span className="text-sm px-3 py-1 rounded-full text-white" style={{ backgroundColor: BRAND_COLORS.primary }}>
                   Owner Statements
                 </span>


### PR DESCRIPTION
## Summary
- center all heading elements across the app
- rename all "IAM CFO" references to "I AM CFO"

## Testing
- `pnpm lint` *(fails: Do not pass children as props; Unexpected any; etc.)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689adb191ba48333809b428b78980419