### PR TITLE
feat: add transaction drilldown APIs

### DIFF
--- a/scripts/create-ai-rollups.sql
+++ b/scripts/create-ai-rollups.sql
@@ -1,0 +1,27 @@
+-- Indexes to speed up journal_entry_lines queries
+CREATE INDEX IF NOT EXISTS jel_date_idx ON public.journal_entry_lines (date);
+CREATE INDEX IF NOT EXISTS jel_class_idx ON public.journal_entry_lines (class);
+CREATE INDEX IF NOT EXISTS jel_vendor_idx ON public.journal_entry_lines (vendor);
+CREATE INDEX IF NOT EXISTS jel_account_type_idx ON public.journal_entry_lines (account_type);
+CREATE INDEX IF NOT EXISTS jel_entry_number_idx ON public.journal_entry_lines (entry_number);
+
+-- Materialized view for monthly rollups used by AI and charts
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_jel_monthly_class AS
+SELECT
+  date_trunc('month', date)::date AS month,
+  COALESCE(class, 'Unassigned') AS class,
+  SUM(CASE WHEN report_category = 'Income' OR account_type = 'Income' THEN amount ELSE 0 END) AS revenue,
+  SUM(CASE WHEN report_category = 'Expense' OR account_type = 'Expense' THEN amount ELSE 0 END) AS expenses,
+  COUNT(*) AS rows
+FROM public.journal_entry_lines
+GROUP BY 1,2;
+
+CREATE INDEX IF NOT EXISTS mv_jel_monthly_class_idx ON mv_jel_monthly_class (month, class);
+
+-- Function and cron job to refresh the materialized view hourly
+CREATE OR REPLACE FUNCTION refresh_ai_rollups() RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY mv_jel_monthly_class;
+END $$;
+
+SELECT cron.schedule('refresh_ai_rollups_hourly', '0 * * * *', $$SELECT refresh_ai_rollups();$$);

--- a/src/app/api/tx/export/route.ts
+++ b/src/app/api/tx/export/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseServer } from '@/lib/supabaseServer'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const MAX_ROWS = 50000
+
+function escapeCSV(value: unknown) {
+  const str = value === null || value === undefined ? '' : String(value)
+  return '"' + str.replace(/"/g, '""') + '"'
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.json()
+  const limit = Math.min(body.limit ?? MAX_ROWS, MAX_ROWS)
+
+  let query = supabaseServer
+    .from('journal_entry_lines')
+    .select(
+      `date,class,vendor,account_name,account_type,memo,amount,debit,credit,entry_number,line_number`
+    )
+
+  if (body.startDate) query = query.gte('date', body.startDate)
+  if (body.endDate) query = query.lte('date', body.endDate)
+  if (body.class && !['All', 'All Classes'].includes(body.class))
+    query = query.eq('class', body.class)
+  if (body.vendor) query = query.eq('vendor', body.vendor)
+  if (body.account_type) query = query.eq('account_type', body.account_type)
+  if (body.account_name) query = query.eq('account_name', body.account_name)
+  if (body.minAmount !== undefined) query = query.gte('amount', body.minAmount)
+  if (body.maxAmount !== undefined) query = query.lte('amount', body.maxAmount)
+  if (body.search) {
+    const q = `%${body.search}%`
+    query = query.or(
+      `memo.ilike.${q},vendor.ilike.${q},name.ilike.${q}`
+    )
+  }
+
+  // default sort by date asc for export
+  query = query
+    .order('date', { ascending: true })
+    .order('entry_number', { ascending: true })
+    .order('line_number', { ascending: true })
+
+  const { data, error } = await query.limit(limit)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const rows = data || []
+  const header = [
+    'date',
+    'class',
+    'vendor',
+    'account_name',
+    'account_type',
+    'memo',
+    'debit',
+    'credit',
+    'amount',
+    'entry_number',
+    'line_number',
+  ]
+
+  const csvLines = [header.join(',')]
+  for (const r of rows) {
+    csvLines.push(
+      [
+        r.date,
+        r.class,
+        r.vendor,
+        r.account_name,
+        r.account_type,
+        r.memo,
+        r.debit,
+        r.credit,
+        r.amount,
+        r.entry_number,
+        r.line_number,
+      ].map(escapeCSV).join(',')
+    )
+  }
+
+  return new NextResponse(csvLines.join('\n'), {
+    headers: {
+      'Content-Type': 'text/csv',
+    },
+  })
+}

--- a/src/app/api/tx/resolve-handle/route.ts
+++ b/src/app/api/tx/resolve-handle/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+interface ResolveBody {
+  handle: string
+  limit?: number
+}
+
+function monthEnd(date: Date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0)
+}
+
+export async function POST(req: NextRequest) {
+  const body: ResolveBody = await req.json()
+  if (!body.handle) {
+    return NextResponse.json({ error: 'handle required' }, { status: 400 })
+  }
+
+  const [kind, vendor, ym, cls] = body.handle.split(':')
+  const filters: Record<string, unknown> = {}
+  if (body.limit) filters.limit = body.limit
+
+  if (kind === 'vd') {
+    filters.vendor = vendor
+    if (cls && !['All', 'All Classes'].includes(cls)) filters.class = cls
+    if (ym) {
+      const [y, m] = ym.split('-').map((v) => parseInt(v, 10))
+      const start = new Date(y, m - 1, 1)
+      const end = monthEnd(start)
+      filters.startDate = `${y}-${String(m).padStart(2, '0')}-01`
+      filters.endDate = `${y}-${String(m).padStart(2, '0')}-${String(end.getDate()).padStart(2, '0')}`
+    }
+  } else {
+    return NextResponse.json({ error: 'unknown handle' }, { status: 400 })
+  }
+
+  return NextResponse.json({ path: '/api/tx/search', body: filters })
+}

--- a/src/app/api/tx/search/route.ts
+++ b/src/app/api/tx/search/route.ts
@@ -1,0 +1,160 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseServer } from '@/lib/supabaseServer'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const MAX_LIMIT = 500
+
+interface SearchBody {
+  startDate?: string
+  endDate?: string
+  class?: string
+  vendor?: string
+  account_type?: string
+  account_name?: string
+  minAmount?: number
+  maxAmount?: number
+  search?: string
+  sort?: 'date_desc' | 'date_asc' | 'amount_desc' | 'amount_asc'
+  cursor?: string | null
+  limit?: number
+}
+
+interface Row {
+  date: string
+  class: string | null
+  vendor: string | null
+  account_name: string | null
+  account_type: string | null
+  memo: string | null
+  amount: number
+  debit: number | null
+  credit: number | null
+  entry_number: string | number | null
+  line_number: number | null
+}
+
+interface Cursor {
+  date: string
+  entry_number: string | number | null
+  line_number: number | null
+  amount: number
+}
+
+function encodeCursor(row: Cursor) {
+  return Buffer.from(JSON.stringify(row)).toString('base64')
+}
+
+function decodeCursor(cursor: string): Cursor {
+  return JSON.parse(Buffer.from(cursor, 'base64').toString('utf8')) as Cursor
+}
+
+export async function POST(req: NextRequest) {
+  const body: SearchBody = await req.json()
+  const limit = Math.min(body.limit ?? 100, MAX_LIMIT)
+  let query = supabaseServer
+    .from('journal_entry_lines')
+    .select(
+      `date,class,vendor,account_name,account_type,memo,amount,debit,credit,entry_number,line_number`
+    )
+
+  if (body.startDate) query = query.gte('date', body.startDate)
+  if (body.endDate) query = query.lte('date', body.endDate)
+  if (body.class && !['All', 'All Classes'].includes(body.class))
+    query = query.eq('class', body.class)
+  if (body.vendor) query = query.eq('vendor', body.vendor)
+  if (body.account_type) query = query.eq('account_type', body.account_type)
+  if (body.account_name) query = query.eq('account_name', body.account_name)
+  if (body.minAmount !== undefined) query = query.gte('amount', body.minAmount)
+  if (body.maxAmount !== undefined) query = query.lte('amount', body.maxAmount)
+  if (body.search) {
+    const q = `%${body.search}%`
+    query = query.or(
+      `memo.ilike.${q},vendor.ilike.${q},name.ilike.${q}`
+    )
+  }
+
+  const sort = body.sort || 'date_desc'
+  switch (sort) {
+    case 'date_asc':
+      query = query
+        .order('date', { ascending: true })
+        .order('entry_number', { ascending: true })
+        .order('line_number', { ascending: true })
+      break
+    case 'amount_desc':
+      query = query
+        .order('amount', { ascending: false })
+        .order('date', { ascending: false })
+        .order('entry_number', { ascending: false })
+        .order('line_number', { ascending: false })
+      break
+    case 'amount_asc':
+      query = query
+        .order('amount', { ascending: true })
+        .order('date', { ascending: true })
+        .order('entry_number', { ascending: true })
+        .order('line_number', { ascending: true })
+      break
+    case 'date_desc':
+    default:
+      query = query
+        .order('date', { ascending: false })
+        .order('entry_number', { ascending: false })
+        .order('line_number', { ascending: false })
+      break
+  }
+
+  if (body.cursor) {
+    const c = decodeCursor(body.cursor)
+    switch (sort) {
+      case 'date_asc':
+        query = query.or(
+          `date.gt.${c.date},and(date.eq.${c.date},entry_number.gt.${c.entry_number}),and(date.eq.${c.date},entry_number.eq.${c.entry_number},line_number.gt.${c.line_number})`
+        )
+        break
+      case 'amount_desc':
+        query = query.or(
+          `amount.lt.${c.amount},and(amount.eq.${c.amount},date.lt.${c.date}),and(amount.eq.${c.amount},date.eq.${c.date},entry_number.lt.${c.entry_number}),and(amount.eq.${c.amount},date.eq.${c.date},entry_number.eq.${c.entry_number},line_number.lt.${c.line_number})`
+        )
+        break
+      case 'amount_asc':
+        query = query.or(
+          `amount.gt.${c.amount},and(amount.eq.${c.amount},date.gt.${c.date}),and(amount.eq.${c.amount},date.eq.${c.date},entry_number.gt.${c.entry_number}),and(amount.eq.${c.amount},date.eq.${c.date},entry_number.eq.${c.entry_number},line_number.gt.${c.line_number})`
+        )
+        break
+      case 'date_desc':
+      default:
+        query = query.or(
+          `date.lt.${c.date},and(date.eq.${c.date},entry_number.lt.${c.entry_number}),and(date.eq.${c.date},entry_number.eq.${c.entry_number},line_number.lt.${c.line_number})`
+        )
+        break
+    }
+  }
+
+  const { data, error } = await query.limit(limit + 1)
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  let rows: Row[] = (data as Row[]) || []
+  const hasNext = rows.length > limit
+  if (hasNext) rows = rows.slice(0, limit)
+  const nextCursor = hasNext ? encodeCursor(rows[rows.length - 1]) : undefined
+
+  const pageTotalAmount = rows.reduce(
+    (sum, r) => sum + (Number(r.amount) || 0),
+    0
+  )
+
+  return NextResponse.json({
+    rows,
+    hasNext,
+    nextCursor,
+    aggregates: {
+      count: rows.length,
+      pageTotalAmount,
+    },
+  })
+}

--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,0 +1,8 @@
+import 'server-only'
+import { createClient } from '@supabase/supabase-js'
+
+export const supabaseServer = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false } }
+)


### PR DESCRIPTION
## Summary
- add SQL indexes and materialized rollup view for AI summaries
- add server-side Supabase client
- implement transaction search, handle resolution, and CSV export APIs

## Testing
- `pnpm lint` *(fails: Do not pass children as props, Unexpected any, etc.)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689af7907a188333bb240b0c0e27999f