### PR TITLE
Limit drilldown columns on financial pages

### DIFF
--- a/src/app/cash-flow/page.tsx
+++ b/src/app/cash-flow/page.tsx
@@ -1379,6 +1379,11 @@ export default function CashFlowPage() {
         bankAccount: row.entry_bank_account,
         accountType: row.account_type,
         reportCategory: row.report_category,
+        entryNumber: row.entry_number,
+        customer: row.customer,
+        vendor: row.vendor,
+        name: row.name,
+        class: row.class,
       }))
 
       setTransactionDetails(transactionDetails)
@@ -3193,22 +3198,16 @@ export default function CashFlowPage() {
                         Date
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Account
+                        Payee/Customer
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Memo
                       </th>
                       <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Cash Flow Impact
+                        Amount
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Bank Account
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Account Type
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Report Category
+                      <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Class
                       </th>
                     </tr>
                   </thead>
@@ -3218,7 +3217,12 @@ export default function CashFlowPage() {
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                           {formatDate(transaction.date)}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{transaction.account}</td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                          {transaction.name ||
+                            transaction.vendor ||
+                            transaction.customer ||
+                            "N/A"}
+                        </td>
                         <td
                           className="px-6 py-4 text-sm text-gray-500 max-w-xs truncate"
                           title={transaction.memo || ""}
@@ -3232,10 +3236,12 @@ export default function CashFlowPage() {
                         >
                           {formatCurrency(transaction.impact)}
                         </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{transaction.bankAccount}</td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{transaction.accountType}</td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          {transaction.reportCategory}
+                        <td className="px-6 py-4 whitespace-nowrap text-center">
+                          {transaction.class && (
+                            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                              {transaction.class}
+                            </span>
+                          )}
                         </td>
                       </tr>
                     ))}

--- a/src/app/financials/page.tsx
+++ b/src/app/financials/page.tsx
@@ -2890,28 +2890,16 @@ export default function FinancialsPage() {
                         Date
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Description
+                        Payee/Customer
                       </th>
                       <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Memo
                       </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Entry #
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider text-center">
-                        Account Type
-                      </th>
                       <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                         Amount
                       </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Debit
-                      </th>
-                      <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Credit
-                      </th>
                       <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
-                        Property
+                        Class
                       </th>
                     </tr>
                   </thead>
@@ -2948,24 +2936,12 @@ export default function FinancialsPage() {
                           <td className="px-6 py-4 text-sm text-gray-500">
                             {transaction.memo || "N/A"}
                           </td>
-                          <td className="px-6 py-4 text-sm text-blue-600">
-                            {transaction.entry_number || "N/A"}
-                          </td>
-                          <td className="px-6 py-4 text-sm text-purple-600 text-center">
-                            {transaction.account_type || "N/A"}
-                          </td>
                           <td
                             className={`px-6 py-4 whitespace-nowrap text-sm text-right font-medium ${
                               netAmount >= 0 ? "text-green-600" : "text-red-600"
                             }`}
                           >
                             {formatCurrency(Math.abs(netAmount))}
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-600">
-                            {debitValue > 0 ? formatCurrency(debitValue) : ""}
-                          </td>
-                          <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-600">
-                            {creditValue > 0 ? formatCurrency(creditValue) : ""}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-center">
                             {transaction.class && (


### PR DESCRIPTION
## Summary
- show only Date, Payee/Customer, Memo, Amount, and Class in P&L drilldown table
- restrict cash flow drilldown to the same columns and capture payee/class info

## Testing
- `pnpm lint` *(fails: react/no-children-prop and other lint errors)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_689b4a5d8b488333aed60c74f8c357bf