### PR TITLE
feat: add comparative analysis and cash flow planner

### DIFF
--- a/src/app/api/cashflow/route.ts
+++ b/src/app/api/cashflow/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server"
+import { createClient } from "@supabase/supabase-js"
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "https://crconmdpaujoeeuadgkd.supabase.co"
+const supabaseKey = process.env.SUPABASE_SERVICE_KEY || ""
+const supabase = createClient(supabaseUrl, supabaseKey)
+
+const startOfISOWeek = (d: Date) => {
+  const date = new Date(d)
+  const day = date.getUTCDay() || 7
+  if (day !== 1) date.setUTCDate(date.getUTCDate() - (day - 1))
+  date.setUTCHours(0, 0, 0, 0)
+  return date.toISOString().split("T")[0]
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const scope = url.searchParams.get("scope") || "All"
+  const horizon = parseInt(url.searchParams.get("horizon") || "13", 10)
+  const histWeeks = parseInt(url.searchParams.get("histWeeks") || "12", 10)
+  const revAdj = parseFloat(url.searchParams.get("revAdjPct") || "0") / 100
+  const opAdj = parseFloat(url.searchParams.get("opexAdjPct") || "0") / 100
+  const arDelay = parseInt(url.searchParams.get("arDelayDays") || "0", 10)
+  const startCash = parseFloat(url.searchParams.get("startCash") || "0")
+
+  const today = new Date()
+  const histStart = new Date(today)
+  histStart.setDate(histStart.getDate() - histWeeks * 7)
+
+  let query = supabase
+    .from("journal_entry_lines")
+    .select("date, class, account_type, report_category, debit, credit")
+    .gte("date", histStart.toISOString().split("T")[0])
+    .lte("date", today.toISOString().split("T")[0])
+
+  if (scope !== "All") {
+    query = query.eq("class", scope)
+  }
+
+  const { data, error } = await query
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  const weeks: Record<string, { inflow: number; outflow: number }> = {}
+  ;(data || []).forEach((r: any) => {
+    const debit = Number(r.debit) || 0
+    const credit = Number(r.credit) || 0
+    const net = debit - credit
+    const wk = startOfISOWeek(new Date(r.date))
+    if (!weeks[wk]) weeks[wk] = { inflow: 0, outflow: 0 }
+    const type = (r.account_type || "").toLowerCase()
+    const cat = (r.report_category || "").toLowerCase()
+    if (cat === "revenue" || type === "income" || type === "other income") {
+      weeks[wk].inflow += net
+    } else if (
+      type === "expense" ||
+      type === "other expense" ||
+      type === "cost of goods sold"
+    ) {
+      weeks[wk].outflow += Math.abs(net)
+    }
+  })
+
+  const weekVals = Object.values(weeks)
+  const avgIn = weekVals.reduce((s, w) => s + w.inflow, 0) / (weekVals.length || 1)
+  const avgOut = weekVals.reduce((s, w) => s + w.outflow, 0) / (weekVals.length || 1)
+
+  const inflows = Array(horizon).fill(avgIn * (1 + revAdj))
+  const outflows = Array(horizon).fill(avgOut * (1 + opAdj))
+
+  const shift = Math.round(arDelay / 7)
+  if (shift > 0) {
+    for (let i = inflows.length - 1; i >= shift; i--) {
+      inflows[i] = inflows[i - shift]
+    }
+    for (let i = 0; i < shift; i++) inflows[i] = 0
+  }
+
+  const result: any[] = []
+  let cash = startCash
+  for (let i = 0; i < horizon; i++) {
+    const weekStart = new Date(today)
+    weekStart.setDate(weekStart.getDate() + i * 7)
+    const inflow = inflows[i]
+    const outflow = outflows[i]
+    const net = inflow - outflow
+    cash += net
+    result.push({
+      weekStart: startOfISOWeek(weekStart),
+      inflow: Number(inflow.toFixed(2)),
+      outflow: Number(outflow.toFixed(2)),
+      net: Number(net.toFixed(2)),
+      endingCash: Number(cash.toFixed(2)),
+    })
+  }
+
+  return NextResponse.json(result)
+}
+
+export async function POST(req: Request) {
+  const body = await req.json()
+  const { name, params } = body
+  const { error } = await supabase
+    .from("cashflow_scenarios")
+    .insert({ name, params, created_at: new Date().toISOString() })
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ status: "ok" })
+}
+

--- a/src/app/cash-flow-planner/page.tsx
+++ b/src/app/cash-flow-planner/page.tsx
@@ -1,0 +1,6 @@
+import CashFlowPlanner from "@/components/dashboard/tabs/CashFlowPlanner"
+
+export default function Page() {
+  return <CashFlowPlanner />
+}
+

--- a/src/app/comparative-analysis/page.tsx
+++ b/src/app/comparative-analysis/page.tsx
@@ -1,0 +1,6 @@
+import ComparativeAnalysis from "@/components/dashboard/tabs/ComparativeAnalysis"
+
+export default function Page() {
+  return <ComparativeAnalysis />
+}
+

--- a/src/components/dashboard/tabs/CashFlowPlanner.tsx
+++ b/src/components/dashboard/tabs/CashFlowPlanner.tsx
@@ -1,0 +1,169 @@
+import React, { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Slider } from "@/components/ui/slider"
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ResponsiveContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip, BarChart, Bar, Legend } from "recharts"
+import Papa from "papaparse"
+
+interface Row {
+  weekStart: string
+  inflow: number
+  outflow: number
+  net: number
+  endingCash: number
+}
+
+export default function CashFlowPlanner() {
+  const [startCash, setStartCash] = useState(10000)
+  const [horizon, setHorizon] = useState(13)
+  const [scope, setScope] = useState("All")
+  const [revAdj, setRevAdj] = useState(0)
+  const [opAdj, setOpAdj] = useState(0)
+  const [arDelay, setArDelay] = useState(0)
+  const [data, setData] = useState<Row[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const fetchData = async () => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams({
+        scope,
+        horizon: horizon.toString(),
+        histWeeks: "12",
+        revAdjPct: revAdj.toString(),
+        opexAdjPct: opAdj.toString(),
+        arDelayDays: arDelay.toString(),
+        startCash: startCash.toString(),
+      })
+      const res = await fetch(`/api/cashflow?${params.toString()}`)
+      const json = await res.json()
+      setData(json)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const exportCSV = () => {
+    const csv = Papa.unparse(data)
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = "cashflow.csv"
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const saveScenario = async () => {
+    const name = prompt("Scenario name?")
+    if (!name) return
+    await fetch("/api/cashflow", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, params: { startCash, horizon, scope, revAdj, opAdj, arDelay } }),
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Cash Flow Planner</CardTitle>
+        </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap items-end gap-2">
+              <Input
+                type="number"
+                value={startCash}
+                onChange={(e) => setStartCash(Number(e.target.value))}
+                placeholder="Starting Cash"
+              />
+            <Input type="number" value={horizon} onChange={(e) => setHorizon(Number(e.target.value))} placeholder="Horizon" />
+            <Select value={scope} onValueChange={setScope}>
+              <SelectTrigger className="w-[180px]"><SelectValue placeholder="Scope" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="All">All</SelectItem>
+                <SelectItem value="Class">Class</SelectItem>
+                <SelectItem value="Property">Property</SelectItem>
+              </SelectContent>
+            </Select>
+            <div className="w-48">
+              <label className="text-xs">Revenue % {revAdj}</label>
+              <Slider value={[revAdj]} onValueChange={(v) => setRevAdj(v[0])} min={-50} max={50} step={1} />
+            </div>
+            <div className="w-48">
+              <label className="text-xs">OpEx % {opAdj}</label>
+              <Slider value={[opAdj]} onValueChange={(v) => setOpAdj(v[0])} min={-50} max={50} step={1} />
+            </div>
+            <div className="w-48">
+              <label className="text-xs">AR Delay {arDelay}d</label>
+              <Slider value={[arDelay]} onValueChange={(v) => setArDelay(v[0])} min={0} max={90} step={7} />
+            </div>
+              <Button onClick={fetchData} disabled={loading}>{loading ? "Loading" : "Refresh"}</Button>
+              <Button className="bg-white text-black border" onClick={exportCSV}>Export CSV</Button>
+              <Button className="bg-white text-black border" onClick={saveScenario}>Save Scenario</Button>
+          </div>
+
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={data}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="weekStart" />
+                <YAxis />
+                <Tooltip />
+                <Line type="monotone" dataKey="endingCash" stroke="#56B6E9" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="weekStart" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="inflow" stackId="a" fill="#56B6E9" />
+                <Bar dataKey="outflow" stackId="a" fill="#E74C3C" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="overflow-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Week</th>
+                  <th className="p-2">Inflows</th>
+                  <th className="p-2">Outflows</th>
+                  <th className="p-2">Net</th>
+                  <th className="p-2">Ending Cash</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((row) => (
+                  <tr key={row.weekStart} className={`border-t ${row.endingCash < 0 ? "bg-red-100" : ""}`}>
+                    <td className="p-2">{row.weekStart}</td>
+                    <td className="p-2">{row.inflow.toFixed(2)}</td>
+                    <td className="p-2">{row.outflow.toFixed(2)}</td>
+                    <td className="p-2">{row.net.toFixed(2)}</td>
+                    <td className="p-2">{row.endingCash.toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/src/components/dashboard/tabs/ComparativeAnalysis.tsx
+++ b/src/components/dashboard/tabs/ComparativeAnalysis.tsx
@@ -1,0 +1,283 @@
+import React, { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, LineChart, Line } from "recharts"
+import { supabase } from "@/lib/supabaseClient"
+import Papa from "papaparse"
+
+type KPISet = {
+  revenue: number
+  cogs: number
+  grossProfit: number
+  opEx: number
+  netIncome: number
+  byAccount: Record<string, number>
+  trend: Record<string, number>
+}
+
+const isIncome = (t: string | null) => {
+  const type = (t || "").toLowerCase()
+  return type === "income" || type === "other income" || type.includes("income") || type.includes("revenue")
+}
+
+const isExpense = (t: string | null) => {
+  const type = (t || "").toLowerCase()
+  return type === "expense" || type === "other expense" || type.includes("expense")
+}
+
+const isCogs = (t: string | null) => {
+  const type = (t || "").toLowerCase()
+  return type === "cost of goods sold" || type.includes("cogs") || type.includes("cost of goods")
+}
+
+const computeKPIs = (rows: any[]): KPISet => {
+  const result: KPISet = {
+    revenue: 0,
+    cogs: 0,
+    grossProfit: 0,
+    opEx: 0,
+    netIncome: 0,
+    byAccount: {},
+    trend: {},
+  }
+
+  rows.forEach((r) => {
+    const debit = Number(r.debit) || 0
+    const credit = Number(r.credit) || 0
+    const account = r.account || "Unknown"
+    const date = r.date?.split("T")[0]
+    const week = date ? new Date(date) : null
+    const weekKey = week ? `${week.getFullYear()}-W${String(Math.ceil((week.getDate() - week.getDay() + 1) / 7)).padStart(2, "0")}` : ""
+
+    if (isIncome(r.account_type)) {
+      const amt = credit - debit
+      result.revenue += amt
+      result.byAccount[account] = (result.byAccount[account] || 0) + amt
+      if (weekKey) result.trend[weekKey] = (result.trend[weekKey] || 0) + amt
+    } else if (isCogs(r.account_type)) {
+      const amt = debit - credit
+      result.cogs += amt
+      result.byAccount[account] = (result.byAccount[account] || 0) - amt
+      if (weekKey) result.trend[weekKey] = (result.trend[weekKey] || 0) - amt
+    } else if (isExpense(r.account_type)) {
+      const amt = debit - credit
+      result.opEx += amt
+      result.byAccount[account] = (result.byAccount[account] || 0) - amt
+      if (weekKey) result.trend[weekKey] = (result.trend[weekKey] || 0) - amt
+    }
+  })
+
+  result.grossProfit = result.revenue - result.cogs
+  result.netIncome = result.grossProfit - result.opEx
+  return result
+}
+
+const kpiOrder = ["Revenue", "COGS", "Gross Profit", "OpEx", "Net Income"]
+
+export default function ComparativeAnalysis() {
+  const today = new Date().toISOString().split("T")[0]
+  const [mode, setMode] = useState<"period" | "scope">("period")
+  const [startA, setStartA] = useState(today)
+  const [endA, setEndA] = useState(today)
+  const [startB, setStartB] = useState(today)
+  const [endB, setEndB] = useState(today)
+  const [scopeA, setScopeA] = useState("All")
+  const [scopeB, setScopeB] = useState("All")
+  const [dataA, setDataA] = useState<KPISet | null>(null)
+  const [dataB, setDataB] = useState<KPISet | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const fetchData = async () => {
+    setLoading(true)
+    try {
+      const filters = async (start: string, end: string, scope: string) => {
+        let query = supabase
+          .from("journal_entry_lines")
+          .select("date, class, account, account_type, debit, credit")
+          .gte("date", start)
+          .lte("date", end)
+        if (scope !== "All") {
+          query = query.eq("class", scope)
+        }
+        const { data } = await query
+        return data || []
+      }
+
+      const rowsA = await filters(startA, endA, scopeA)
+      const rowsB = await filters(mode === "period" ? startB : startA, mode === "period" ? endB : endA, scopeB)
+      setDataA(computeKPIs(rowsA))
+      setDataB(computeKPIs(rowsB))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const kpiData = kpiOrder.map((k) => {
+    const key = k
+    const map: any = {
+      Revenue: { a: dataA?.revenue || 0, b: dataB?.revenue || 0 },
+      COGS: { a: dataA?.cogs || 0, b: dataB?.cogs || 0 },
+      "Gross Profit": { a: dataA?.grossProfit || 0, b: dataB?.grossProfit || 0 },
+      OpEx: { a: dataA?.opEx || 0, b: dataB?.opEx || 0 },
+      "Net Income": { a: dataA?.netIncome || 0, b: dataB?.netIncome || 0 },
+    }
+    return { kpi: key, A: map[key].a, B: map[key].b }
+  })
+
+  const topMovers = (() => {
+    const accs = new Set<string>([
+      ...(dataA ? Object.keys(dataA.byAccount) : []),
+      ...(dataB ? Object.keys(dataB.byAccount) : []),
+    ])
+    const arr = Array.from(accs).map((acct) => {
+      const a = dataA?.byAccount[acct] || 0
+      const b = dataB?.byAccount[acct] || 0
+      const varAmt = a - b
+      const varPct = b === 0 ? 0 : (varAmt / Math.abs(b)) * 100
+      return { account: acct, A: a, B: b, varAmt, varPct }
+    })
+    return arr.sort((x, y) => Math.abs(y.varAmt) - Math.abs(x.varAmt)).slice(0, 10)
+  })()
+
+  const trendData = (() => {
+    const keys = new Set<string>([
+      ...(dataA ? Object.keys(dataA.trend) : []),
+      ...(dataB ? Object.keys(dataB.trend) : []),
+    ])
+    return Array.from(keys)
+      .sort()
+      .map((k) => ({
+        period: k,
+        A: dataA?.trend[k] || 0,
+        B: dataB?.trend[k] || 0,
+      }))
+  })()
+
+  const summary = (() => {
+    if (!dataA || !dataB) return []
+    const revVarPct = ((dataA.revenue - dataB.revenue) / (dataB.revenue || 1)) * 100
+    const opVarPct = ((dataA.opEx - dataB.opEx) / (dataB.opEx || 1)) * 100
+    const niVarPct = ((dataA.netIncome - dataB.netIncome) / (Math.abs(dataB.netIncome) || 1)) * 100
+    return [
+      `Revenue ${revVarPct >= 0 ? "up" : "down"} ${Math.abs(revVarPct).toFixed(1)}%`,
+      `OpEx ${opVarPct >= 0 ? "up" : "down"} ${Math.abs(opVarPct).toFixed(1)}%`,
+      `Net Income ${niVarPct >= 0 ? "up" : "down"} ${Math.abs(niVarPct).toFixed(1)}%`,
+    ]
+  })()
+
+  const exportCSV = () => {
+    const csv = Papa.unparse(topMovers)
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = "comparative-analysis.csv"
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Comparative Analysis</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-end gap-2">
+            <Select value={mode} onValueChange={(v) => setMode(v as any)}>
+              <SelectTrigger className="w-[180px]"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="period">Period vs Period</SelectItem>
+                <SelectItem value="scope">Class/Property vs Class/Property</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input type="date" value={startA} onChange={(e) => setStartA(e.target.value)} />
+            <Input type="date" value={endA} onChange={(e) => setEndA(e.target.value)} />
+            {mode === "period" ? (
+              <>
+                <Input type="date" value={startB} onChange={(e) => setStartB(e.target.value)} />
+                <Input type="date" value={endB} onChange={(e) => setEndB(e.target.value)} />
+              </>
+            ) : (
+              <>
+                <Input value={scopeA} onChange={(e) => setScopeA(e.target.value)} placeholder="Scope A" />
+                <Input value={scopeB} onChange={(e) => setScopeB(e.target.value)} placeholder="Scope B" />
+              </>
+            )}
+            <Button onClick={fetchData} disabled={loading}>{loading ? "Loading" : "Refresh"}</Button>
+            <Button className="bg-white text-black border" onClick={exportCSV}>Export CSV</Button>
+          </div>
+
+          {summary.length > 0 && (
+            <ul className="list-disc pl-5 text-sm">
+              {summary.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ul>
+          )}
+
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={kpiData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="kpi" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="A" fill="#56B6E9" />
+                <Bar dataKey="B" fill="#94A3B8" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={trendData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="period" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="A" stroke="#56B6E9" />
+                <Line type="monotone" dataKey="B" stroke="#94A3B8" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+
+          <div className="overflow-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left">
+                  <th className="p-2">Account</th>
+                  <th className="p-2">A</th>
+                  <th className="p-2">B</th>
+                  <th className="p-2">Var $</th>
+                  <th className="p-2">Var %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topMovers.map((row) => (
+                  <tr key={row.account} className="border-t">
+                    <td className="p-2">{row.account}</td>
+                    <td className="p-2">{row.A.toFixed(2)}</td>
+                    <td className="p-2">{row.B.toFixed(2)}</td>
+                    <td className="p-2">{row.varAmt.toFixed(2)}</td>
+                    <td className="p-2">{row.varPct.toFixed(2)}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+Input.displayName = "Input"
+
+export { Input }
+

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+import { cn } from "@/lib/utils"
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn("relative flex w-full touch-none select-none items-center", className)}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-5 w-5 rounded-full border-2 border-primary bg-background shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+))
+Slider.displayName = SliderPrimitive.Root.displayName
+
+export { Slider }
+

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,3 +1,4 @@
 declare module "jspdf";
 declare module "jspdf-autotable";
 declare module "xlsx";
+declare module "papaparse";


### PR DESCRIPTION
## Summary
- add comparative analysis tab with KPI bars, trend lines, and top movers table
- add cash flow planner with forecast controls and charts
- expose cash flow forecast API and scenarios table insert

## Testing
- `pnpm lint` *(fails: numerous existing lint errors)*
- `pnpm type-check` *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689b56fff158833382f0b1946179f3c5