### PR TITLE
fix: improve dropdown readability

### DIFF
--- a/src/app/comparative-analysis/page.tsx
+++ b/src/app/comparative-analysis/page.tsx
@@ -248,6 +248,12 @@ export default function ComparativeAnalysisPage() {
     }
   };
 
+  useEffect(() => {
+    if (allLinesA.length || allLinesB.length) {
+      setLineData(buildLineData(allLinesA, allLinesB, selectedKpi));
+    }
+  }, [selectedKpi, allLinesA, allLinesB]);
+
   const barChartData =
     dataA && dataB
       ? [
@@ -498,17 +504,36 @@ export default function ComparativeAnalysisPage() {
       )}
 
       {lineData.length > 0 && (
-        <div className="w-full h-64">
-          <ResponsiveContainer>
-            <LineChart data={lineData}>
-              <XAxis dataKey="date" />
-              <YAxis tickFormatter={(v) => formatCurrency(v)} />
-              <Tooltip formatter={(value) => formatCurrency(Number(value))} />
-              <Legend />
-              <Line type="monotone" dataKey="A" stroke="#56B6E9" />
-              <Line type="monotone" dataKey="B" stroke="#94A3B8" />
-            </LineChart>
-          </ResponsiveContainer>
+        <div className="w-full">
+          <div className="flex justify-end mb-2">
+            <Select
+              value={selectedKpi}
+              onValueChange={(v) => setSelectedKpi(v as keyof KPIs)}
+            >
+              <SelectTrigger className="w-48">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="revenue">Revenue</SelectItem>
+                <SelectItem value="cogs">COGS</SelectItem>
+                <SelectItem value="grossProfit">Gross Profit</SelectItem>
+                <SelectItem value="opEx">OpEx</SelectItem>
+                <SelectItem value="netIncome">Net Income</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="h-64">
+            <ResponsiveContainer>
+              <LineChart data={lineData} margin={{ left: 40, right: 20 }}>
+                <XAxis dataKey="date" />
+                <YAxis tickFormatter={(v) => formatCurrency(v)} />
+                <Tooltip formatter={(value) => formatCurrency(Number(value))} />
+                <Legend />
+                <Line type="monotone" dataKey="A" stroke="#56B6E9" />
+                <Line type="monotone" dataKey="B" stroke="#94A3B8" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       )}
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border bg-white dark:bg-gray-800 px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -61,7 +61,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-white text-gray-900 dark:bg-gray-800 dark:text-gray-100 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className


### PR DESCRIPTION
## Summary
- ensure dropdown trigger and menu have solid backgrounds so text doesn't mix with page content

## Testing
- `pnpm lint` (fails: multiple lint errors)
- `pnpm type-check` (fails: multiple type errors)


------
https://chatgpt.com/codex/tasks/task_e_689b92532e288333b1fa47e64a6208ed