### PR TITLE
Reorder Balance Sheet link ahead of Comparative Analysis

### DIFF
--- a/src/app/ClientRootLayout.tsx
+++ b/src/app/ClientRootLayout.tsx
@@ -52,12 +52,12 @@ const navigation = [
   { name: "Overview", href: "/", icon: BarChart3 },
   { name: "P&L", href: "/financials", icon: TrendingUp },
   { name: "Cash Flow", href: "/cash-flow", icon: DollarSign },
+  { name: "Balance Sheet", href: "/balance-sheet", icon: FileText },
   {
     name: "Comparative Analysis",
     href: "/comparative-analysis",
     icon: BarChart2,
   },
-  { name: "Balance Sheet", href: "/balance-sheet", icon: FileText },
   { name: "A/R", href: "/accounts-receivable", icon: CreditCard },
   { name: "A/P", href: "/accounts-payable", icon: Users },
   { name: "Settings", href: "/settings", icon: Settings },


### PR DESCRIPTION
## Summary
- Position Balance Sheet link above Comparative Analysis in main navigation

## Testing
- `pnpm lint` *(fails: Do not pass children as props; Unexpected any etc.)*
- `pnpm type-check` *(fails: Property 'growth' does not exist on type 'never', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689df36917408333b125bc219371297b